### PR TITLE
Update bcrypt to fixe nodejs 0.11 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jshint": "*"
   },
   "dependencies":{
-    "bcrypt": "~0.7.8",
+    "bcrypt": "~0.8.0",
     "lodash": "~2.4.1",
     "moment": "~2.7.0",
     "nodemailer": "~0.6.5",


### PR DESCRIPTION
Tested on a local project and fixes the nodejs 0.11 install issue.
