### PR TITLE
update dependencies, test for node 0.12 and iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
 node_js:
-- "0.10"
-- "0.11"
+- "0.10.36"
+- "0.12"
+- "iojs"
 
 env:
   - COVERAGE=true

--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
     "jshint": "*"
   },
   "dependencies":{
-    "bcrypt": "~0.8.0",
+    "bcrypt": "~0.8.1",
     "lodash": "~2.4.1",
-    "moment": "~2.7.0",
-    "nodemailer": "~0.6.5",
+    "moment": "~2.9.0",
+    "nodemailer": "~1.3.0",
     "jade": "~1.3.1",
     "jwt-simple": "~0.2.0",
-    "node-uuid": "~1.4.1"
+    "node-uuid": "~1.4.2"
   },
   "author": "David Rivera <david.r.rivera193@gmail.com>",
-  "contributors": [ 
+  "contributors": [
     {
       "name": "David Rivera",
       "email": "david.r.rivera193@gmail.com"
-    } 
+    }
   ],
   "license": "MIT",
   "bugs": {
@@ -47,6 +47,6 @@
   "homepage": "https://github.com/davidrivera/waterlock-local-auth",
   "preferGlobal": false,
   "engines": {
-    "node": ">=0.6"
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
* addresses issues #18 and #4
* deprecate support for unstable node 0.11
* bump minimum supported node to 0.10.36 - previous stable with security patches