### PR TITLE
Adding POST password param check

### DIFF
--- a/lib/controllers/actions/login.js
+++ b/lib/controllers/actions/login.js
@@ -9,7 +9,7 @@ module.exports = function(req, res){
   var scope = require('../../scope')(waterlock.Auth, waterlock.engine);
   var params = req.params.all();
   
-  if(typeof params[scope.type] === 'undefined' || typeof params.password === 'undefined'){
+  if(typeof params[scope.type] === 'undefined' || typeof params.password !== 'string'){
     waterlock.cycle.loginFailure(req, res, null, {error: 'Invalid '+scope.type+' or password'});
   }else{
     var pass = params.password;


### PR DESCRIPTION
When password param from request is not a string you should crash your app.
This problem was found when R httr POST sent an array rather than a string.
>> {"email":["test@test.com"],"password":["test12345"]}