### PR TITLE
change Bcrypt for bcryptjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 # sublime project files
 *.sublime-project
 *.sublime-workspace
+.idea

--- a/lib/controllers/actions/login.js
+++ b/lib/controllers/actions/login.js
@@ -1,5 +1,5 @@
 'use strict';
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcryptjs');
 
 /**
  * Login action

--- a/lib/models/auth.js
+++ b/lib/models/auth.js
@@ -32,7 +32,7 @@ exports.attributes = function(attr){
  */
 exports.beforeCreate = function(values){
     if(typeof values.password !== 'undefined'){
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcryptjs');
     var salt = bcrypt.genSaltSync(10);
     var hash = bcrypt.hashSync(values.password, salt);
     values.password = hash;    
@@ -46,7 +46,7 @@ exports.beforeCreate = function(values){
  */
 exports.beforeUpdate = function(values){
   if(typeof values.password !== 'undefined'){
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcryptjs');
     var salt = bcrypt.genSaltSync(10);
     var hash = bcrypt.hashSync(values.password, salt);
     values.password = hash;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jshint": "*"
   },
   "dependencies":{
-    "bcrypt": "~0.8.1",
+    "bcryptjs": "~0.8.2",
     "lodash": "~2.4.1",
     "moment": "~2.9.0",
     "nodemailer": "~1.3.0",


### PR DESCRIPTION
bcryptjs is API compatible to bcrypt but 100% pure JS, which avoids issues with the node-gyp compiling, for example having the wrong python version and similar issues.

Basically, it is the same thing but just JS, so no issues caused by the native stuff, which makes for better forward and backwards compatibility and an easier time when deploying. Always bet on JS™ :)