### PR TITLE
login should return 400 on E_VALIDATION error instead of 500

### DIFF
--- a/lib/controllers/actions/login.js
+++ b/lib/controllers/actions/login.js
@@ -15,7 +15,11 @@ module.exports = function(req, res){
     var pass = params.password;
     scope.getUserAuthObject(params, req, function(err, user){
       if (err) {
-        return res.serverError(err);
+        if (err.code === 'E_VALIDATION') {
+          return res.status(400).json(err);
+        } else {
+          return res.serverError(err);
+        }
       }
       if (user) {
         if(bcrypt.compareSync(pass, user.auth.password)){


### PR DESCRIPTION
While trying to integrate waterlock-local-auth with angular recently, I've noticed two things happening on login waterline validation failures:

1. res.serverError() is removing the response body in production mode, preventing angular from seeing which fields failed to validate
2. res.serverError() is returning a 500 Server Error when we should really be returning 400 Bad Request

This commit ensures 400 + error body is always returned on E_VALIDATION errors for login, and defaults to res.serverError(err) for anything else.

Thoughts?