### PR TITLE
update bcrypt version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jshint": "*"
   },
   "dependencies":{
-    "bcrypt": "~0.8.1",
+    "bcrypt": "~0.8.3",
     "lodash": "~2.4.1",
     "moment": "~2.9.0",
     "nodemailer": "0.7.1",


### PR DESCRIPTION
This fixes the bug where we currently need to run `npm install waterlock-local-auth` before running the server each time.