### PR TITLE
adds a response when no user is found on password resets

### DIFF
--- a/lib/controllers/actions/reset.js
+++ b/lib/controllers/actions/reset.js
@@ -89,6 +89,7 @@ function handlePost(req, res, sails, params){
  */
 function sendEmail(req, res, sails, params){
   sails.models.auth.findOne({email: params.email}).populate('user').exec(function(err, a){
+
     if(a){
       sails.models.resettoken.create({owner: a.id}).exec(function(err, t){
         if(err){
@@ -101,6 +102,8 @@ function sendEmail(req, res, sails, params){
           res.json(200);
         });
       });
+    } else {
+      res.json(404);
     }
   });
 }


### PR DESCRIPTION
I can't take credit for this fix, but came across the same issue and implemented what @leejt489 suggested here: https://github.com/waterlock/waterlock-local-auth/issues/13