### PR TITLE
Removing protocol parameter from nodemailer.createTransport()

### DIFF
--- a/lib/waterlock-local-auth.js
+++ b/lib/waterlock-local-auth.js
@@ -40,7 +40,7 @@ if(_.isObject(method) &&
   method.passwordReset.tokens){
   var nodemailer = require('nodemailer');
   var mail = method.passwordReset.mail;
-  var smtpTransport = nodemailer.createTransport(mail.protocol, mail.options);
+  var smtpTransport = nodemailer.createTransport(mail.options);
   exports.transport = smtpTransport;
 }
 


### PR DESCRIPTION
Otherwise an Exception is thrown when waterlock tries to send the reset email.
```
[Error: Unsupported configuration, downgrade Nodemailer to v0.7.1 or see the migration guide https://github.com/andris9/Nodemailer#migration-guide]
```