### PR TITLE
Returning error when email sent for reset is not found

### DIFF
--- a/lib/controllers/actions/reset.js
+++ b/lib/controllers/actions/reset.js
@@ -101,6 +101,8 @@ function sendEmail(req, res, sails, params){
           res.json(200);
         });
       });
+    } else {
+      return res.forbidden('Email not found');
     }
   });
 }


### PR DESCRIPTION
Currently server hangs when email sent over POST is not found in Auth model. Added a ```else``` condition