### PR TITLE
Fix crash on register, bug #106

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -37,7 +37,7 @@ function generateScope(scopeKey, engine){
 
       this.engine.findAuth(criteria, function(err, user) {
         if (user) {
-          cb();
+          return cb();
         }
         self.engine.findOrCreateAuth(criteria, attr, cb);
       });


### PR DESCRIPTION
Fixed bug in registration that crashed the server when registering wtth an existing email. (issue #106)

Fixes issue #106 (https://github.com/waterlock/waterlock/issues/106)