### PR TITLE
Path.normalize would break without the leading slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ node_modules
 # sublime project files
 *.sublime-project
 *.sublime-workspace
+
+env

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ exports.getHtmlEmail = function(token){
   var viewVars = authConfig.passwordReset.template.vars;
   viewVars.url = resetUrl;
 
-  var templatePath = path.normalize(__dirname+'../../../'+authConfig.passwordReset.template.file);
+  var templatePath = path.normalize(__dirname+'/../../../'+authConfig.passwordReset.template.file);
   var html = jade.renderFile(templatePath, viewVars);
 
   return html;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -4,6 +4,30 @@ var waterlock = testHelper.waterlock_local;
 var proxyquire = testHelper.proxyquire;
 
 describe('utils',function(){
+
+  it('missing slash after __dirname fails', function(done) {
+    var utils = proxyquire('../lib/utils',
+      {
+        './waterlock-local-auth': waterlock,
+        'path': {
+          normalize: function(str) {
+            return __dirname+"./email.test.jade";
+          }
+        }
+      });
+
+    var error = new Error('ENOENT: no such file or directory, open \''+__dirname+'./email.test.jade\'');
+    error.errno = -2;
+    error.code = 'ENOENT';
+    error.syscall = 'open';
+    error.path = __dirname+'./email.test.jade';
+
+    (function(){
+      utils.getHtmlEmail({owner: "test", resetToken: "token"})
+    }).should.throwError(error);
+    done();
+  });
+
   var utils = proxyquire('../lib/utils',
     {
       './waterlock-local-auth': waterlock,


### PR DESCRIPTION
In utils, if the leading slash was gone from the path.normalize when rendering the template path, it would look in the wrong location for the template and break the sending of emails.
