### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/models/resetToken.js
+++ b/lib/models/resetToken.js
@@ -27,7 +27,7 @@ exports.beforeCreate = function(values, cb){
   var jwt = require('jwt-simple');
   var config = require('../waterlock-local-auth').config;
   var issued = Date.now();
-  var uuid = require('node-uuid');
+  var uuid = require('uuid');
   var moment = require('moment')();
   var expiration = moment.add(1, 'hours');
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "authentication",
     "sails"
   ],
-  "devDependencies":{
+  "devDependencies": {
     "mocha": "*",
     "should": "*",
     "proxyquire": "*",
@@ -24,14 +24,14 @@
     "istanbul": "*",
     "jshint": "*"
   },
-  "dependencies":{
+  "dependencies": {
     "bcrypt": "~0.8.5",
+    "jade": "~1.11.0",
+    "jwt-simple": "~0.3.0",
     "lodash": "~3.10.0",
     "moment": "~2.10.6",
     "nodemailer": "1.4.0",
-    "jade": "~1.11.0",
-    "jwt-simple": "~0.3.0",
-    "node-uuid": "~1.4.2"
+    "uuid": "^3.0.0"
   },
   "author": "David Rivera <david.r.rivera193@gmail.com>",
   "contributors": [


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.