### PR TITLE
[EDIT] Use bcrypt-node instead of C++ bcrypt

### DIFF
--- a/lib/controllers/actions/login.js
+++ b/lib/controllers/actions/login.js
@@ -1,5 +1,5 @@
 'use strict';
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcrypt-nodejs');
 
 /**
  * Login action

--- a/lib/controllers/actions/register.js
+++ b/lib/controllers/actions/register.js
@@ -1,5 +1,5 @@
 'use strict';
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcrypt-nodejs');
 
 /**
  * Login action

--- a/lib/models/auth.js
+++ b/lib/models/auth.js
@@ -32,7 +32,7 @@ exports.attributes = function(attr){
  */
 exports.beforeCreate = function(values){
     if(!_.isUndefined(values.password)){
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcrypt-nodejs');
     var salt = bcrypt.genSaltSync(10);
     var hash = bcrypt.hashSync(values.password, salt);
     values.password = hash;
@@ -46,7 +46,7 @@ exports.beforeCreate = function(values){
  */
 exports.beforeUpdate = function(values){
   if(!_.isUndefined(values.password) && values.password !== null){
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcrypt-nodejs');
     var salt = bcrypt.genSaltSync(10);
     var hash = bcrypt.hashSync(values.password, salt);
     values.password = hash;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "authentication",
     "sails"
   ],
-  "devDependencies":{
+  "devDependencies": {
     "mocha": "*",
     "should": "*",
     "proxyquire": "*",
@@ -24,14 +24,14 @@
     "istanbul": "*",
     "jshint": "*"
   },
-  "dependencies":{
-    "bcrypt": "~0.8.5",
-    "lodash": "~3.10.0",
-    "moment": "~2.10.6",
-    "nodemailer": "1.4.0",
+  "dependencies": {
+    "bcrypt-nodejs": "0.0.3",
     "jade": "~1.11.0",
     "jwt-simple": "~0.3.0",
-    "node-uuid": "~1.4.2"
+    "lodash": "~3.10.0",
+    "moment": "~2.10.6",
+    "node-uuid": "~1.4.2",
+    "nodemailer": "1.4.0"
   },
   "author": "David Rivera <david.r.rivera193@gmail.com>",
   "contributors": [


### PR DESCRIPTION
I had an issue in my server caused by missing GCC library called GLIBCXX_3.4.21.
That was needed by bcrypt library.

I just replaced bcrypt with its native javascript alternative "bcrypt-node"
That will save time to a lot of people