### PR TITLE
Change type 'email' to type 'string'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Local auth adds the following attributes onto the Auth model
 
 ```js
   email: {
-    type: 'email',
+    type: 'string',
     unique: true
   },
   password: {

--- a/lib/models/auth.js
+++ b/lib/models/auth.js
@@ -5,7 +5,7 @@ var _  = require('lodash');
 exports.attributes = function(attr){
   var template = {
     email: {
-      type: 'email',
+      type: 'string',
       unique: true
     },
     password: {


### PR DESCRIPTION
Hello, as far as I know, type "email" is not supported but instead "string"
This was giving me compilation errors when trying "sails lift" 
Regards